### PR TITLE
Fix wrong Picker import

### DIFF
--- a/components/TournamentScreen.tsx
+++ b/components/TournamentScreen.tsx
@@ -3,8 +3,9 @@ import React, { useState } from 'react';
 import {
   ScrollView, View, Text, StyleSheet, TouchableOpacity, FlatList,
   Modal, TextInput, TouchableWithoutFeedback, Keyboard,
-  KeyboardAvoidingView, Platform, Alert, Picker
+  KeyboardAvoidingView, Platform, Alert
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { Ionicons } from '@expo/vector-icons';
 
 const publicTournaments = [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-picker/picker": "^2.4.8"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- fix import for `Picker` in `TournamentScreen`
- add `@react-native-picker/picker` dependency

## Testing
- `npm run lint` *(fails: expo not found)*
